### PR TITLE
Remove reset to avoid passing by reference

### DIFF
--- a/src/Message/Headers.php
+++ b/src/Message/Headers.php
@@ -34,7 +34,8 @@ class Headers
 
     public function getHeaderValue($search)
     {
-        return reset($this->getHeaderValues($search));
+        $values = $this->getHeaderValues($search);
+        return $values[0];
     }
 
     public function getAll()


### PR DESCRIPTION
I got the following warning when running examples/google.php.

```
PHP Strict Standards:  Only variables should be passed by reference 
in /Users/masakielastic/test/php-buzz-react/src/Message/Headers.php on line 39
```

I confirmed the bahavior of `reset`.

``` php
function test()
{
    return array('a', 'b', 'c');
}

var_dump(
    reset(test()),
    array_shift(test())
);
```

http://3v4l.org/CZi6i
