### PR TITLE
Add HTTP timeout option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "react/http-client": "^0.5.8",
         "react/promise": "^2.2.1 || ^1.2.1",
         "react/promise-stream": "^1.0 || ^0.1.1",
+        "react/promise-timer": "^1.2",
         "react/socket": "^1.1",
         "react/stream": "^1.0 || ^0.7",
         "ringcentral/psr7": "^1.2"

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -253,6 +253,7 @@ class Browser
      *
      * ```php
      * $newBrowser = $browser->withOptions(array(
+     *     'timeout' => null,
      *     'followRedirects' => true,
      *     'maxRedirects' => 10,
      *     'obeySuccessCode' => true,
@@ -260,8 +261,8 @@ class Browser
      * ));
      * ```
      *
-     * See also [redirects](#redirects) and [streaming](#streaming) for more
-     * details.
+     * See also [timeouts](#timeouts), [redirects](#redirects) and
+     * [streaming](#streaming) for more details.
      *
      * Notice that the [`Browser`](#browser) is an immutable object, i.e. this
      * method actually returns a *new* [`Browser`](#browser) instance with the

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -19,6 +19,9 @@ class Browser
     private $messageFactory;
     private $baseUri = null;
 
+    /** @var LoopInterface $loop */
+    private $loop;
+
     /**
      * The `Browser` is responsible for sending HTTP requests to your HTTP server
      * and keeps track of pending incoming HTTP responses.
@@ -58,7 +61,8 @@ class Browser
         $this->messageFactory = new MessageFactory();
         $this->transaction = new Transaction(
             Sender::createFromLoop($loop, $connector, $this->messageFactory),
-            $this->messageFactory
+            $this->messageFactory,
+            $loop
         );
     }
 

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -115,6 +115,27 @@ class FunctionalBrowserTest extends TestCase
     }
 
     /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Request timed out after 0.1 seconds
+     * @group online
+     */
+    public function testTimeoutDelayedResponseShouldReject()
+    {
+        $promise = $this->browser->withOptions(array('timeout' => 0.1))->get($this->base . 'delay/10');
+
+        Block\await($promise, $this->loop);
+    }
+
+    /**
+     * @group online
+     * @doesNotPerformAssertions
+     */
+    public function testTimeoutNegativeShouldResolveSuccessfully()
+    {
+        Block\await($this->browser->withOptions(array('timeout' => -1))->get($this->base . 'get'), $this->loop);
+    }
+
+    /**
      * @group online
      * @doesNotPerformAssertions
      */


### PR DESCRIPTION
This now respects PHP's `default_socket_timeout` setting (default 60s) as a timeout for sending the outgoing HTTP request and waiting for a successful response and will otherwise cancel the pending request and reject its value with an Exception. You can now use the [`timeout` option](#withoptions) to pass a custom timeout value in seconds like this:

```php
$browser = $browser->withOptions(array(
    'timeout' => 10.0
));

$browser->get($uri)->then(function (ResponseInterface $response) {
    // response received within 10 seconds maximum
    var_dump($response->getHeaders());
});
```

Similarly, you can use a negative timeout value to not apply a timeout at all or use a `null` value to restore the default handling.

Supersedes / closes #90, thank you @Rakdar!
Resolves / closes #1