### PR TITLE
Add `Content-Length: 0` request header for empty POST etc.

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -77,14 +77,30 @@ class Browser
     }
 
     /**
+     *
+     * This method will automatically add a matching `Content-Length` request
+     * header if the outgoing request body is a `string`. If you're using a
+     * streaming request body (`ReadableStreamInterface`), it will default to
+     * using `Transfer-Encoding: chunked` or you have to explicitly pass in a
+     * matching `Content-Length` request header like so:
+     *
+     * ```php
+     * $body = new ThroughStream();
+     * $loop->addTimer(1.0, function () use ($body) {
+     *     $body->end("hello world");
+     * });
+     *
+     * $browser->post($url, array('Content-Length' => '11'), $body);
+     * ```
+     *
      * @param string|UriInterface            $url     URI for the request.
      * @param array                          $headers
-     * @param string|ReadableStreamInterface $content
+     * @param string|ReadableStreamInterface $contents
      * @return PromiseInterface
      */
-    public function post($url, array $headers = array(), $content = '')
+    public function post($url, array $headers = array(), $contents = '')
     {
-        return $this->send($this->messageFactory->request('POST', $url, $headers, $content));
+        return $this->send($this->messageFactory->request('POST', $url, $headers, $contents));
     }
 
     /**
@@ -98,36 +114,68 @@ class Browser
     }
 
     /**
+     *
+     * This method will automatically add a matching `Content-Length` request
+     * header if the outgoing request body is a `string`. If you're using a
+     * streaming request body (`ReadableStreamInterface`), it will default to
+     * using `Transfer-Encoding: chunked` or you have to explicitly pass in a
+     * matching `Content-Length` request header like so:
+     *
+     * ```php
+     * $body = new ThroughStream();
+     * $loop->addTimer(1.0, function () use ($body) {
+     *     $body->end("hello world");
+     * });
+     *
+     * $browser->patch($url, array('Content-Length' => '11'), $body);
+     * ```
+     *
      * @param string|UriInterface            $url     URI for the request.
      * @param array                          $headers
-     * @param string|ReadableStreamInterface $content
+     * @param string|ReadableStreamInterface $contents
      * @return PromiseInterface
      */
-    public function patch($url, array $headers = array(), $content = '')
+    public function patch($url, array $headers = array(), $contents = '')
     {
-        return $this->send($this->messageFactory->request('PATCH', $url , $headers, $content));
+        return $this->send($this->messageFactory->request('PATCH', $url , $headers, $contents));
+    }
+
+    /**
+     *
+     * This method will automatically add a matching `Content-Length` request
+     * header if the outgoing request body is a `string`. If you're using a
+     * streaming request body (`ReadableStreamInterface`), it will default to
+     * using `Transfer-Encoding: chunked` or you have to explicitly pass in a
+     * matching `Content-Length` request header like so:
+     *
+     * ```php
+     * $body = new ThroughStream();
+     * $loop->addTimer(1.0, function () use ($body) {
+     *     $body->end("hello world");
+     * });
+     *
+     * $browser->put($url, array('Content-Length' => '11'), $body);
+     * ```
+     *
+     * @param string|UriInterface            $url     URI for the request.
+     * @param array                          $headers
+     * @param string|ReadableStreamInterface $contents
+     * @return PromiseInterface
+     */
+    public function put($url, array $headers = array(), $contents = '')
+    {
+        return $this->send($this->messageFactory->request('PUT', $url, $headers, $contents));
     }
 
     /**
      * @param string|UriInterface            $url     URI for the request.
      * @param array                          $headers
-     * @param string|ReadableStreamInterface $content
+     * @param string|ReadableStreamInterface $contents
      * @return PromiseInterface
      */
-    public function put($url, array $headers = array(), $content = '')
+    public function delete($url, array $headers = array(), $contents = '')
     {
-        return $this->send($this->messageFactory->request('PUT', $url, $headers, $content));
-    }
-
-    /**
-     * @param string|UriInterface            $url     URI for the request.
-     * @param array                          $headers
-     * @param string|ReadableStreamInterface $content
-     * @return PromiseInterface
-     */
-    public function delete($url, array $headers = array(), $content = '')
-    {
-        return $this->send($this->messageFactory->request('DELETE', $url, $headers, $content));
+        return $this->send($this->messageFactory->request('DELETE', $url, $headers, $contents));
     }
 
     /**
@@ -136,6 +184,9 @@ class Browser
      * ```php
      * $browser->submit($url, array('user' => 'test', 'password' => 'secret'));
      * ```
+     *
+     * This method will automatically add a matching `Content-Length` request
+     * header for the encoded length of the given `$fields`.
      *
      * @param string|UriInterface $url     URI for the request.
      * @param array               $fields
@@ -146,9 +197,9 @@ class Browser
     public function submit($url, array $fields, $headers = array(), $method = 'POST')
     {
         $headers['Content-Type'] = 'application/x-www-form-urlencoded';
-        $content = http_build_query($fields);
+        $contents = http_build_query($fields);
 
-        return $this->send($this->messageFactory->request($method, $url, $headers, $content));
+        return $this->send($this->messageFactory->request($method, $url, $headers, $contents));
     }
 
     /**
@@ -164,6 +215,12 @@ class Browser
      *
      * $browser->send($request)->then(…);
      * ```
+     *
+     * This method will automatically add a matching `Content-Length` request
+     * header if the size of the outgoing request body is known and non-empty.
+     * For an empty request body, if will only include a `Content-Length: 0`
+     * request header if the request method usually expects a request body (only
+     * applies to `POST`, `PUT` and `PATCH`).
      *
      * @param RequestInterface $request
      * @return PromiseInterface

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -76,22 +76,21 @@ class Sender
      */
     public function send(RequestInterface $request)
     {
-        $uri = $request->getUri();
-
-        // URIs are required to be absolute for the HttpClient to work
-        if ($uri->getScheme() === '' || $uri->getHost() === '') {
-            return \React\Promise\reject(new \InvalidArgumentException('Sending request requires absolute URI with scheme and host'));
-        }
-
         $body = $request->getBody();
+        $size = $body->getSize();
 
-        // automatically assign a Content-Length header if the body size is known
-        if ($body->getSize() !== null && $body->getSize() !== 0 && !$request->hasHeader('Content-Length')) {
-            $request = $request->withHeader('Content-Length', (string)$body->getSize());
-        }
-
-        if ($body instanceof ReadableStreamInterface && $body->isReadable() && !$request->hasHeader('Content-Length')) {
+        if ($size !== null && $size !== 0) {
+            // automatically assign a "Content-Length" request header if the body size is known and non-empty
+            $request = $request->withHeader('Content-Length', (string)$size);
+        } elseif ($size === 0 && \in_array($request->getMethod(), array('POST', 'PUT', 'PATCH'))) {
+            // only assign a "Content-Length: 0" request header if the body is expected for certain methods
+            $request = $request->withHeader('Content-Length', '0');
+        } elseif ($body instanceof ReadableStreamInterface && $body->isReadable() && !$request->hasHeader('Content-Length')) {
+            // use "Transfer-Encoding: chunked" when this is a streaming body and body size is unknown
             $request = $request->withHeader('Transfer-Encoding', 'chunked');
+        } else {
+            // do not use chunked encoding if size is known or if this is an empty request body
+            $size = 0;
         }
 
         $headers = array();
@@ -99,7 +98,7 @@ class Sender
             $headers[$name] = implode(', ', $values);
         }
 
-        $requestStream = $this->http->request($request->getMethod(), (string)$uri, $headers, $request->getProtocolVersion());
+        $requestStream = $this->http->request($request->getMethod(), (string)$request->getUri(), $headers, $request->getProtocolVersion());
 
         $deferred = new Deferred(function ($_, $reject) use ($requestStream) {
             // close request stream if request is cancelled
@@ -125,7 +124,7 @@ class Sender
 
         if ($body instanceof ReadableStreamInterface) {
             if ($body->isReadable()) {
-                if ($request->hasHeader('Content-Length')) {
+                if ($size !== null) {
                     // length is known => just write to request
                     $body->pipe($requestStream);
                 } else {

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -308,8 +308,7 @@ class FunctionalBrowserTest extends TestCase
         $stream = new ThroughStream();
 
         $this->loop->addTimer(0.001, function () use ($stream) {
-            $stream->emit('data', array('hello world'));
-            $stream->close();
+            $stream->end('hello world');
         });
 
         $response = Block\await($this->browser->post($this->base . 'post', array('Content-Length' => 11), $stream), $this->loop);


### PR DESCRIPTION
Add documentation for when this library will automatically add an
outgoing `Content-Length` request header and that this header should
only be passed manually for request streaming.

Additionally, we now make sure to include a `Content-Length: 0` request
header if the request body is known to be empty and the request method
usually expects a request body (only applies to `POST`, `PUT` and
`PATCH`). While not strictly required by the newer RFC 7230, this does
improve compatibility with some HTTP servers which seem to follow the
older RFC 2616 semantics.

Resolves / closes #117