### PR TITLE
Revert timeouts to throwing a TimeoutException (Fixes #123)

### DIFF
--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -10,7 +10,6 @@ use Psr\Http\Message\UriInterface;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
-use React\Promise\Timer\TimeoutException;
 use React\Stream\ReadableStreamInterface;
 
 /**
@@ -87,14 +86,7 @@ class Transaction
             return $deferred->promise();
         }
 
-        return \React\Promise\Timer\timeout($deferred->promise(), $timeout, $this->loop)->then(null, function ($e) {
-            if ($e instanceof TimeoutException) {
-                throw new \RuntimeException(
-                    'Request timed out after ' . $e->getTimeout() . ' seconds'
-                );
-            }
-            throw $e;
-        });
+        return \React\Promise\Timer\timeout($deferred->promise(), $timeout, $this->loop);
     }
 
     private function next(RequestInterface $request, Deferred $deferred)

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -8,6 +8,7 @@ use React\EventLoop\Factory;
 use React\Http\Response;
 use React\Http\StreamingServer;
 use React\Promise\Stream;
+use React\Promise\Timer\TimeoutException;
 use React\Socket\Connector;
 use React\Stream\ThroughStream;
 use RingCentral\Psr7\Request;
@@ -115,15 +116,20 @@ class FunctionalBrowserTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Request timed out after 0.1 seconds
      * @group online
      */
     public function testTimeoutDelayedResponseShouldReject()
     {
-        $promise = $this->browser->withOptions(array('timeout' => 0.1))->get($this->base . 'delay/10');
+        $caught = false;
+        try {
+            $promise = $this->browser->withOptions(array('timeout' => 0.1))->get($this->base . 'delay/10');
 
-        Block\await($promise, $this->loop);
+            Block\await($promise, $this->loop);
+        } catch (TimeoutException $e) {
+            $caught = true;
+            $this->assertEquals(0.1, $e->getTimeout());
+        }
+        $this->assertTrue($caught);
     }
 
     /**


### PR DESCRIPTION
Changes related to the timeout changes in 2.5.0 rewrote TimeoutExceptions to bare RuntimeExceptions with no access to the previous exception, making it much harder to programmatically handle Timeouts (and breaking timeout handling in existing projects).

I've reverted these changes and updated the tests so they perform the same checks (including the timeout length, which I assume is to ensure some other timeout doesn't trigger a pass)

ReactPHP's TimeoutExceptions already extend RuntimeException, so anyone who's updated their code or otherwise written timeout handling against 2.5.0 shouldn't experience a breaking change.