### PR TITLE
Only try to follow redirects if Location response header is present

### DIFF
--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -165,7 +165,9 @@ class Transaction
     {
         $this->progress('response', array($response, $request));
 
-        if ($this->followRedirects && ($response->getStatusCode() >= 300 && $response->getStatusCode() < 400)) {
+        // follow 3xx (Redirection) response status codes if Location header is present and not explicitly disabled
+        // @link https://tools.ietf.org/html/rfc7231#section-6.4
+        if ($this->followRedirects && ($response->getStatusCode() >= 300 && $response->getStatusCode() < 400) && $response->hasHeader('Location')) {
             return $this->onResponseRedirect($response, $request, $deferred);
         }
 

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -179,6 +179,15 @@ class FunctionalBrowserTest extends TestCase
      * @group online
      * @doesNotPerformAssertions
      */
+    public function testResponseStatus300WithoutLocationShouldResolveWithoutFollowingRedirect()
+    {
+        Block\await($this->browser->get($this->base . 'status/300'), $this->loop);
+    }
+
+    /**
+     * @group online
+     * @doesNotPerformAssertions
+     */
     public function testCanAccessHttps()
     {
         if (!function_exists('stream_socket_enable_crypto')) {


### PR DESCRIPTION
Only try to follow redirects with `3xx` (Redirection) response status if response contains a `Location` response header. This fixes `304` (Not Modified) and `300` (Multiple Choices) responses which usually do not include a `Location` response header.

See also https://stackoverflow.com/questions/16194988/for-which-3xx-http-codes-is-the-location-header-mandatory

Resolves #128 