### PR TITLE
Reject request when streaming request body emits error or closes unexpectedly

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,10 @@ $loop->addTimer(1.0, function () use ($body) {
 $browser->post($url, array('Content-Length' => '11'), $body);
 ```
 
+If the streaming request body emits an `error` event or is explicitly closed
+without emitting a successful `end` event first, the request will automatically
+be closed and rejected.
+
 #### submit()
 
 The `submit($url, array $fields, $headers = array(), $method = 'POST'): PromiseInterface<ResponseInterface>` method can be used to

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -138,7 +138,7 @@ class FunctionalBrowserTest extends TestCase
     {
         $stream = new ThroughStream();
         $promise = $this->browser->withOptions(array('timeout' => 0.1))->post($this->base . 'delay/10', array(), $stream);
-        $stream->close();
+        $stream->end();
 
         Block\await($promise, $this->loop);
     }


### PR DESCRIPTION
Builds on top of #150 and #148