### PR TITLE
Explicitly close connection after response body ends

### DIFF
--- a/tests/Message/MessageFactoryTest.php
+++ b/tests/Message/MessageFactoryTest.php
@@ -96,4 +96,87 @@ class MessageFactoryTest extends TestCase
         $this->assertEquals(null, $body->getSize());
         $this->assertEquals('', (string)$body);
     }
+
+    public function testResponseWithBodyString()
+    {
+        $response = $this->messageFactory->response('1.1', 200, 'OK', array(), 'hi');
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertNotInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertEquals(2, $body->getSize());
+        $this->assertEquals('hi', (string)$body);
+    }
+
+    public function testResponseWithStreamingBodyHasUnknownSizeByDefault()
+    {
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $response = $this->messageFactory->response('1.1', 200, 'OK', array(), $stream);
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertNull($body->getSize());
+        $this->assertEquals('', (string)$body);
+    }
+
+    public function testResponseWithStreamingBodyHasSizeFromContentLengthHeader()
+    {
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $response = $this->messageFactory->response('1.1', 200, 'OK', array('Content-Length' => '100'), $stream);
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertEquals(100, $body->getSize());
+        $this->assertEquals('', (string)$body);
+    }
+
+    public function testResponseWithStreamingBodyHasUnknownSizeWithTransferEncodingChunkedHeader()
+    {
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $response = $this->messageFactory->response('1.1', 200, 'OK', array('Transfer-Encoding' => 'chunked'), $stream);
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertNull($body->getSize());
+        $this->assertEquals('', (string)$body);
+    }
+
+    public function testResponseWithStreamingBodyHasZeroSizeForInformationalResponse()
+    {
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $response = $this->messageFactory->response('1.1', 101, 'OK', array('Content-Length' => '100'), $stream);
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertEquals(0, $body->getSize());
+        $this->assertEquals('', (string)$body);
+    }
+
+    public function testResponseWithStreamingBodyHasZeroSizeForNoContentResponse()
+    {
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $response = $this->messageFactory->response('1.1', 204, 'OK', array('Content-Length' => '100'), $stream);
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertEquals(0, $body->getSize());
+        $this->assertEquals('', (string)$body);
+    }
+
+    public function testResponseWithStreamingBodyHasZeroSizeForNotModifiedResponse()
+    {
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $response = $this->messageFactory->response('1.1', 304, 'OK', array('Content-Length' => '100'), $stream);
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertEquals(0, $body->getSize());
+        $this->assertEquals('', (string)$body);
+    }
 }

--- a/tests/Message/ReadableBodyStreamTest.php
+++ b/tests/Message/ReadableBodyStreamTest.php
@@ -86,6 +86,84 @@ class ReadableBodyStreamTest extends TestCase
         $this->assertEquals(1, $called);
     }
 
+    public function testEndInputWillEmitErrorEventWhenDataDoesNotReachExpectedLength()
+    {
+        $this->input = new ThroughStream();
+        $this->stream = new ReadableBodyStream($this->input, 5);
+
+        $called = null;
+        $this->stream->on('error', function ($e) use (&$called) {
+            $called = $e;
+        });
+
+        $this->input->write('hi');
+        $this->input->end();
+
+        $this->assertInstanceOf('UnderflowException', $called);
+        $this->assertSame('Unexpected end of response body after 2/5 bytes', $called->getMessage());
+    }
+
+    public function testDataEventOnInputWillEmitDataEvent()
+    {
+        $this->input = new ThroughStream();
+        $this->stream = new ReadableBodyStream($this->input);
+
+        $called = null;
+        $this->stream->on('data', function ($data) use (&$called) {
+            $called = $data;
+        });
+
+        $this->input->write('hello');
+
+        $this->assertEquals('hello', $called);
+    }
+
+    public function testDataEventOnInputWillEmitEndWhenDataReachesExpectedLength()
+    {
+        $this->input = new ThroughStream();
+        $this->stream = new ReadableBodyStream($this->input, 5);
+
+        $called = null;
+        $this->stream->on('end', function () use (&$called) {
+            ++$called;
+        });
+
+        $this->input->write('hello');
+
+        $this->assertEquals(1, $called);
+    }
+
+    public function testEndEventOnInputWillEmitEndOnlyOnceWhenDataAlreadyReachedExpectedLength()
+    {
+        $this->input = new ThroughStream();
+        $this->stream = new ReadableBodyStream($this->input, 5);
+
+        $called = null;
+        $this->stream->on('end', function () use (&$called) {
+            ++$called;
+        });
+
+        $this->input->write('hello');
+        $this->input->end();
+
+        $this->assertEquals(1, $called);
+    }
+
+    public function testDataEventOnInputWillNotEmitEndWhenDataDoesNotReachExpectedLength()
+    {
+        $this->input = new ThroughStream();
+        $this->stream = new ReadableBodyStream($this->input, 5);
+
+        $called = null;
+        $this->stream->on('end', function () use (&$called) {
+            ++$called;
+        });
+
+        $this->input->write('hi');
+
+        $this->assertNull($called);
+    }
+
     public function testPauseWillPauseInputStream()
     {
         $this->input->expects($this->once())->method('pause');


### PR DESCRIPTION
This changeset ensures we explicitly close the connection after receiving the complete response body. This improves support for servers ignoring the `Connection: close` request header that would otherwise keep the connection open and would eventually run into a timeout even though the transfer was completed.

Resolves #102