### PR TITLE
Fix HEAD requests to no longer expect a response body

### DIFF
--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -111,14 +111,15 @@ class Sender
         });
 
         $messageFactory = $this->messageFactory;
-        $requestStream->on('response', function (ResponseStream $responseStream) use ($deferred, $messageFactory) {
+        $requestStream->on('response', function (ResponseStream $responseStream) use ($deferred, $messageFactory, $request) {
             // apply response header values from response stream
             $deferred->resolve($messageFactory->response(
                 $responseStream->getVersion(),
                 $responseStream->getCode(),
                 $responseStream->getReasonPhrase(),
                 $responseStream->getHeaders(),
-                $responseStream
+                $responseStream,
+                $request->getMethod()
             ));
         });
 

--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -37,17 +37,18 @@ class MessageFactory
      * @param string $reason
      * @param array  $headers
      * @param ReadableStreamInterface|string $body
+     * @param ?string $requestMethod
      * @return Response
      * @uses self::body()
      */
-    public function response($protocolVersion, $status, $reason, $headers = array(), $body = '')
+    public function response($protocolVersion, $status, $reason, $headers = array(), $body = '', $requestMethod = null)
     {
         $response = new Response($status, $headers, $body instanceof ReadableStreamInterface ? null : $body, $protocolVersion, $reason);
 
         if ($body instanceof ReadableStreamInterface) {
             $length = null;
             $code = $response->getStatusCode();
-            if (($code >= 100 && $code < 200) || $code == 204 || $code == 304) {
+            if ($requestMethod === 'HEAD' || ($code >= 100 && $code < 200) || $code == 204 || $code == 304) {
                 $length = 0;
             } elseif (\strtolower($response->getHeaderLine('Transfer-Encoding')) === 'chunked') {
                 $length = null;

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -516,4 +516,26 @@ class FunctionalBrowserTest extends TestCase
 
         $socket->close();
     }
+
+    public function testHeadRequestReceivesResponseWithEmptyBodyButWithContentLengthResponseHeader()
+    {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
+            return new Response(
+                200,
+                array(),
+                'hello'
+            );
+        });
+        $socket = new \React\Socket\Server(0, $this->loop);
+        $server->listen($socket);
+
+        $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
+
+        $response = Block\await($this->browser->head($this->base . 'get'), $this->loop);
+        $this->assertEquals('', (string)$response->getBody());
+        $this->assertEquals(0, $response->getBody()->getSize());
+        $this->assertEquals('5', $response->getHeaderLine('Content-Length'));
+
+        $socket->close();
+    }
 }

--- a/tests/Message/MessageFactoryTest.php
+++ b/tests/Message/MessageFactoryTest.php
@@ -179,4 +179,16 @@ class MessageFactoryTest extends TestCase
         $this->assertEquals(0, $body->getSize());
         $this->assertEquals('', (string)$body);
     }
+
+    public function testResponseWithStreamingBodyHasZeroSizeForHeadRequestMethod()
+    {
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $response = $this->messageFactory->response('1.1', 200, 'OK', array('Content-Length' => '100'), $stream, 'HEAD');
+
+        $body = $response->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertEquals(0, $body->getSize());
+        $this->assertEquals('', (string)$body);
+    }
 }


### PR DESCRIPTION
Fixes #165
This bug was caused by #161 introduced in `v2.8.0`.