### PR TITLE
Fix unneeded timeout timer when request body closes and sender already rejected

### DIFF
--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -105,8 +105,10 @@ class Transaction
         $body = $request->getBody();
         if ($body instanceof ReadableStreamInterface && $body->isReadable()) {
             $that = $this;
-            $body->on('close', function () use ($that, $deferred, $timeout) {
-                $that->applyTimeout($deferred, $timeout);
+            $body->on('close', function () use ($that, $deferred, &$timeout) {
+                if ($timeout >= 0) {
+                    $that->applyTimeout($deferred, $timeout);
+                }
             });
         } else {
             $this->applyTimeout($deferred, $timeout);


### PR DESCRIPTION
Fixes a rare edge case and subtle regression introduced via #151.
Builds on top of #164 and #168 