### PR TITLE
Add dedicated methods to control options, deprecate `withOptions()`

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -459,6 +459,163 @@ class Browser
     }
 
     /**
+     * Changes the maximum timeout used for waiting for pending requests.
+     *
+     * You can pass in the number of seconds to use as a new timeout value:
+     *
+     * ```php
+     * $browser = $browser->withTimeout(10.0);
+     * ```
+     *
+     * You can pass in a bool `false` to disable any timeouts. In this case,
+     * requests can stay pending forever:
+     *
+     * ```php
+     * $browser = $browser->withTimeout(false);
+     * ```
+     *
+     * You can pass in a bool `true` to re-enable default timeout handling. This
+     * will respects PHP's `default_socket_timeout` setting (default 60s):
+     *
+     * ```php
+     * $browser = $browser->withTimeout(true);
+     * ```
+     *
+     * See also [timeouts](#timeouts) for more details about timeout handling.
+     *
+     * Notice that the [`Browser`](#browser) is an immutable object, i.e. this
+     * method actually returns a *new* [`Browser`](#browser) instance with the
+     * given timeout value applied.
+     *
+     * @param bool|number $timeout
+     * @return self
+     */
+    public function withTimeout($timeout)
+    {
+        if ($timeout === true) {
+            $timeout = null;
+        } elseif ($timeout === false) {
+            $timeout = -1;
+        } elseif ($timeout < 0) {
+            $timeout = 0;
+        }
+
+        return $this->withOptions(array(
+            'timeout' => $timeout,
+        ));
+    }
+
+    /**
+     * Changes how HTTP redirects will be followed.
+     *
+     * You can pass in the maximum number of redirects to follow:
+     *
+     * ```php
+     * $new = $browser->withFollowRedirects(5);
+     * ```
+     *
+     * The request will automatically be rejected when the number of redirects
+     * is exceeded. You can pass in a `0` to reject the request for any
+     * redirects encountered:
+     *
+     * ```php
+     * $browser = $browser->withFollowRedirects(0);
+     *
+     * $browser->get($url)->then(function (Psr\Http\Message\ResponseInterface $response) {
+     *     // only non-redirected responses will now end up here
+     *     var_dump($response->getHeaders());
+     * });
+     * ```
+     *
+     * You can pass in a bool `false` to disable following any redirects. In
+     * this case, requests will resolve with the redirection response instead
+     * of following the `Location` response header:
+     *
+     * ```php
+     * $browser = $browser->withFollowRedirects(false);
+     *
+     * $browser->get($url)->then(function (Psr\Http\Message\ResponseInterface $response) {
+     *     // any redirects will now end up here
+     *     var_dump($response->getHeaderLine('Location'));
+     * });
+     * ```
+     *
+     * You can pass in a bool `true` to re-enable default redirect handling.
+     * This defaults to following a maximum of 10 redirects:
+     *
+     * ```php
+     * $browser = $browser->withFollowRedirects(true);
+     * ```
+     *
+     * See also [redirects](#redirects) for more details about redirect handling.
+     *
+     * Notice that the [`Browser`](#browser) is an immutable object, i.e. this
+     * method actually returns a *new* [`Browser`](#browser) instance with the
+     * given redirect setting applied.
+     *
+     * @param bool|int $followRedirects
+     * @return self
+     */
+    public function withFollowRedirects($followRedirects)
+    {
+        return $this->withOptions(array(
+            'followRedirects' => $followRedirects !== false,
+            'maxRedirects' => \is_bool($followRedirects) ? null : $followRedirects
+        ));
+    }
+
+    /**
+     * Changes whether non-successful HTTP response status codes (4xx and 5xx) will be rejected.
+     *
+     * You can pass in a bool `false` to disable rejecting incoming responses
+     * that use a 4xx or 5xx response status code. In this case, requests will
+     * resolve with the response message indicating an error condition:
+     *
+     * ```php
+     * $browser = $browser->withRejectErrorResponse(false);
+     *
+     * $browser->get($url)->then(function (Psr\Http\Message\ResponseInterface $response) {
+     *     // any HTTP response will now end up here
+     *     var_dump($response->getStatusCode(), $response->getReasonPhrase());
+     * });
+     * ```
+     *
+     * You can pass in a bool `true` to re-enable default status code handling.
+     * This defaults to rejecting any response status codes in the 4xx or 5xx
+     * range:
+     *
+     * ```php
+     * $browser = $browser->withRejectErrorResponse(true);
+     *
+     * $browser->get($url)->then(function (Psr\Http\Message\ResponseInterface $response) {
+     *     // any successful HTTP response will now end up here
+     *     var_dump($response->getStatusCode(), $response->getReasonPhrase());
+     * }, function (Exception $e) {
+     *     if ($e instanceof Clue\React\Buzz\Message\ResponseException) {
+     *         // any HTTP response error message will now end up here
+     *         $response = $e->getResponse();
+     *         var_dump($response->getStatusCode(), $response->getReasonPhrase());
+     *     } else {
+     *         var_dump($e->getMessage());
+     *     }
+     * });
+     * ```
+     *
+     * Notice that the [`Browser`](#browser) is an immutable object, i.e. this
+     * method actually returns a *new* [`Browser`](#browser) instance with the
+     * given setting applied.
+     *
+     * @param bool $obeySuccessCode
+     * @return self
+     */
+    public function withRejectErrorResponse($obeySuccessCode)
+    {
+        return $this->withOptions(array(
+            'obeySuccessCode' => $obeySuccessCode,
+        ));
+    }
+
+    /**
      * Changes the base URL used to resolve relative URLs to.
      *
      * ```php
@@ -524,92 +681,6 @@ class Browser
     }
 
     /**
-     * @param int $timeout
-     *
-     * @return Browser
-     */
-    public function withTimeout($timeout)
-    {
-        return $this->withOptions(array(
-            'timeout' => $timeout,
-        ));
-    }
-
-    /**
-     * @param bool $followRedirects
-     *
-     * @return Browser
-     */
-    public function withFollowRedirects($followRedirects)
-    {
-        return $this->withOptions(array(
-            'followRedirects' => $followRedirects,
-        ));
-    }
-
-    /**
-     * @param int $maxRedirects
-     *
-     * @return Browser
-     */
-    public function withMaxRedirects($maxRedirects)
-    {
-        return $this->withOptions(array(
-            'maxRedirects' => $maxRedirects,
-        ));
-    }
-
-    /**
-     * @param bool $obeySuccessCode
-     *
-     * @return Browser
-     */
-    public function withObeySuccessCode($obeySuccessCode)
-    {
-        return $this->withOptions(array(
-            'obeySuccessCode' => $obeySuccessCode,
-        ));
-    }
-
-    /**
-     * Changes the [options](#options) to use:
-     *
-     * The [`Browser`](#browser) class exposes several options for the handling of
-     * HTTP transactions. These options resemble some of PHP's
-     * [HTTP context options](http://php.net/manual/en/context.http.php) and
-     * can be controlled via the following API (and their defaults):
-     *
-     * ```php
-     * $newBrowser = $browser->withOptions(array(
-     *     'timeout' => null,
-     *     'followRedirects' => true,
-     *     'maxRedirects' => 10,
-     *     'obeySuccessCode' => true,
-     *     'streaming' => false, // deprecated, see requestStreaming() instead
-     * ));
-     * ```
-     *
-     * See also [timeouts](#timeouts), [redirects](#redirects) and
-     * [streaming](#streaming) for more details.
-     *
-     * Notice that the [`Browser`](#browser) is an immutable object, i.e. this
-     * method actually returns a *new* [`Browser`](#browser) instance with the
-     * options applied.
-     *
-     * @param array $options
-     * @return self
-     *
-     * @deprecated Since 2.8.0 use withTimeout, withFollowRedirects, withMaxRedirects, or withObeySuccessCode instead.
-     */
-    public function withOptions(array $options)
-    {
-        $browser = clone $this;
-        $browser->transaction = $this->transaction->withOptions($options);
-
-        return $browser;
-    }
-
-    /**
      * Changes the HTTP protocol version that will be used for all subsequent requests.
      *
      * All the above [request methods](#request-methods) default to sending
@@ -644,6 +715,47 @@ class Browser
 
         $browser = clone $this;
         $browser->protocolVersion = (string) $protocolVersion;
+
+        return $browser;
+    }
+
+    /**
+     * [Deprecated] Changes the [options](#options) to use:
+     *
+     * The [`Browser`](#browser) class exposes several options for the handling of
+     * HTTP transactions. These options resemble some of PHP's
+     * [HTTP context options](http://php.net/manual/en/context.http.php) and
+     * can be controlled via the following API (and their defaults):
+     *
+     * ```php
+     * // deprecated
+     * $newBrowser = $browser->withOptions(array(
+     *     'timeout' => null, // see withTimeout() instead
+     *     'followRedirects' => true, // see withFollowRedirects() instead
+     *     'maxRedirects' => 10, // see withFollowRedirects() instead
+     *     'obeySuccessCode' => true, // see withRejectErrorResponse() instead
+     *     'streaming' => false, // deprecated, see requestStreaming() instead
+     * ));
+     * ```
+     *
+     * See also [timeouts](#timeouts), [redirects](#redirects) and
+     * [streaming](#streaming) for more details.
+     *
+     * Notice that the [`Browser`](#browser) is an immutable object, i.e. this
+     * method actually returns a *new* [`Browser`](#browser) instance with the
+     * options applied.
+     *
+     * @param array $options
+     * @return self
+     * @deprecated 2.9.0 See self::withTimeout(), self::withFollowRedirects() and self::withRejectErrorResponse() instead.
+     * @see self::withTimeout()
+     * @see self::withFollowRedirects()
+     * @see self::withRejectErrorResponse()
+     */
+    public function withOptions(array $options)
+    {
+        $browser = clone $this;
+        $browser->transaction = $this->transaction->withOptions($options);
 
         return $browser;
     }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -524,6 +524,54 @@ class Browser
     }
 
     /**
+     * @param int $timeout
+     *
+     * @return Browser
+     */
+    public function withTimeout($timeout)
+    {
+        return $this->withOptions(array(
+            'timeout' => $timeout,
+        ));
+    }
+
+    /**
+     * @param bool $followRedirects
+     *
+     * @return Browser
+     */
+    public function withFollowRedirects($followRedirects)
+    {
+        return $this->withOptions(array(
+            'followRedirects' => $followRedirects,
+        ));
+    }
+
+    /**
+     * @param int $maxRedirects
+     *
+     * @return Browser
+     */
+    public function withMaxRedirects($maxRedirects)
+    {
+        return $this->withOptions(array(
+            'maxRedirects' => $maxRedirects,
+        ));
+    }
+
+    /**
+     * @param bool $obeySuccessCode
+     *
+     * @return Browser
+     */
+    public function withObeySuccessCode($obeySuccessCode)
+    {
+        return $this->withOptions(array(
+            'obeySuccessCode' => $obeySuccessCode,
+        ));
+    }
+
+    /**
      * Changes the [options](#options) to use:
      *
      * The [`Browser`](#browser) class exposes several options for the handling of
@@ -550,6 +598,8 @@ class Browser
      *
      * @param array $options
      * @return self
+     *
+     * @deprecated Since 2.8.0 use withTimeout, withFollowRedirects, withMaxRedirects, or withObeySuccessCode instead.
      */
     public function withOptions(array $options)
     {

--- a/src/Message/ResponseException.php
+++ b/src/Message/ResponseException.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
  * The `ResponseException` is an `Exception` sub-class that will be used to reject
  * a request promise if the remote server returns a non-success status code
  * (anything but 2xx or 3xx).
- * You can control this behavior via the ["obeySuccessCode" option](#options).
+ * You can control this behavior via the [`withRejectErrorResponse()` method](#withrejecterrorresponse).
  *
  * The `getCode(): int` method can be used to
  * return the HTTP response status code.

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -133,6 +133,76 @@ class BrowserTest extends TestCase
         $this->browser->submit('http://example.com/', array());
     }
 
+    public function testWithTimeoutTrueSetsDefaultTimeoutOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => null))->willReturnSelf();
+
+        $this->browser->withTimeout(true);
+    }
+
+    public function testWithTimeoutFalseSetsNegativeTimeoutOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => -1))->willReturnSelf();
+
+        $this->browser->withTimeout(false);
+    }
+
+    public function testWithTimeout10SetsTimeoutOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => 10))->willReturnSelf();
+
+        $this->browser->withTimeout(10);
+    }
+
+    public function testWithTimeoutNegativeSetsZeroTimeoutOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => null))->willReturnSelf();
+
+        $this->browser->withTimeout(-10);
+    }
+
+    public function testWithFollowRedirectsTrueSetsSenderOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => true, 'maxRedirects' => null))->willReturnSelf();
+
+        $this->browser->withFollowRedirects(true);
+    }
+
+    public function testWithFollowRedirectsFalseSetsSenderOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => false, 'maxRedirects' => null))->willReturnSelf();
+
+        $this->browser->withFollowRedirects(false);
+    }
+
+    public function testWithFollowRedirectsTenSetsSenderOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => true, 'maxRedirects' => 10))->willReturnSelf();
+
+        $this->browser->withFollowRedirects(10);
+    }
+
+    public function testWithFollowRedirectsZeroSetsSenderOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => true, 'maxRedirects' => 0))->willReturnSelf();
+
+        $this->browser->withFollowRedirects(0);
+    }
+
+    public function testWithRejectErrorResponseTrueSetsSenderOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('obeySuccessCode' => true))->willReturnSelf();
+
+        $this->browser->withRejectErrorResponse(true);
+    }
+
+    public function testWithRejectErrorResponseFalseSetsSenderOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('obeySuccessCode' => false))->willReturnSelf();
+
+        $this->browser->withRejectErrorResponse(false);
+    }
+
     public function testWithBase()
     {
         $browser = $this->browser->withBase('http://example.com/root');

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -244,9 +244,9 @@ class FunctionalBrowserTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testTimeoutNegativeShouldResolveSuccessfully()
+    public function testTimeoutFalseShouldResolveSuccessfully()
     {
-        Block\await($this->browser->withTimeout(-1)->get($this->base . 'get'), $this->loop);
+        Block\await($this->browser->withTimeout(false)->get($this->base . 'get'), $this->loop);
     }
 
     /**
@@ -268,16 +268,16 @@ class FunctionalBrowserTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testNotFollowingRedirectsResolvesWithRedirectResult()
+    public function testFollowingRedirectsFalseResolvesWithRedirectResult()
     {
         $browser = $this->browser->withFollowRedirects(false);
 
         Block\await($browser->get($this->base . 'redirect-to?url=get'), $this->loop);
     }
 
-    public function testRejectingRedirectsRejects()
+    public function testFollowRedirectsZeroRejectsOnRedirect()
     {
-        $browser = $this->browser->withMaxRedirects(0);
+        $browser = $this->browser->withFollowRedirects(0);
 
         $this->setExpectedException('RuntimeException');
         Block\await($browser->get($this->base . 'redirect-to?url=get'), $this->loop);
@@ -366,6 +366,13 @@ class FunctionalBrowserTest extends TestCase
             $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $e->getResponse());
             $this->assertEquals(404, $e->getResponse()->getStatusCode());
         }
+    }
+
+    public function testErrorStatusCodeDoesNotRejectWithRejectErrorResponseFalse()
+    {
+        $response = Block\await($this->browser->withRejectErrorResponse(false)->get($this->base . 'status/404'), $this->loop);
+
+        $this->assertEquals(404, $response->getStatusCode());
     }
 
     public function testPostString()

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -225,7 +225,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testTimeoutDelayedResponseShouldReject()
     {
-        $promise = $this->browser->withOptions(array('timeout' => 0.1))->get($this->base . 'delay/10');
+        $promise = $this->browser->withTimeout(0.1)->get($this->base . 'delay/10');
 
         $this->setExpectedException('RuntimeException', 'Request timed out after 0.1 seconds');
         Block\await($promise, $this->loop);
@@ -234,7 +234,7 @@ class FunctionalBrowserTest extends TestCase
     public function testTimeoutDelayedResponseAfterStreamingRequestShouldReject()
     {
         $stream = new ThroughStream();
-        $promise = $this->browser->withOptions(array('timeout' => 0.1))->post($this->base . 'delay/10', array(), $stream);
+        $promise = $this->browser->withTimeout(0.1)->post($this->base . 'delay/10', array(), $stream);
         $stream->end();
 
         $this->setExpectedException('RuntimeException', 'Request timed out after 0.1 seconds');
@@ -246,7 +246,7 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testTimeoutNegativeShouldResolveSuccessfully()
     {
-        Block\await($this->browser->withOptions(array('timeout' => -1))->get($this->base . 'get'), $this->loop);
+        Block\await($this->browser->withTimeout(-1)->get($this->base . 'get'), $this->loop);
     }
 
     /**
@@ -270,14 +270,14 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testNotFollowingRedirectsResolvesWithRedirectResult()
     {
-        $browser = $this->browser->withOptions(array('followRedirects' => false));
+        $browser = $this->browser->withFollowRedirects(false);
 
         Block\await($browser->get($this->base . 'redirect-to?url=get'), $this->loop);
     }
 
     public function testRejectingRedirectsRejects()
     {
-        $browser = $this->browser->withOptions(array('maxRedirects' => 0));
+        $browser = $this->browser->withMaxRedirects(0);
 
         $this->setExpectedException('RuntimeException');
         Block\await($browser->get($this->base . 'redirect-to?url=get'), $this->loop);


### PR DESCRIPTION
This changeset deprecates the generic `withOptions()` method and adds dedicate methods to control all options:

```php
// old: deprecated
$browser->withOptions(['timeout' => 10]);
$browser->withOptions(['followRedirects' => false]);
$browser->withOptions(['obeySuccessCode' => false]);

// new
$browser->withTimeout(10);
$browser->withFollowRedirects(false);
$browser->withRejectErrorResponse(false);
```

Supersedes / closes #155, thanks @WyriHaximus for the original version!
Resolves #154
Builds on top of #170