### PR TITLE
Improve `withBase()` method and deprecate `withoutBase()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ mess with most of the low-level details.
         * [withFollowRedirects()](#withfollowredirects)
         * [withRejectErrorResponse()](#withrejecterrorresponse)
         * [withBase()](#withbase)
-        * [withoutBase()](#withoutbase)
         * [withProtocolVersion()](#withprotocolversion)
         * [~~withOptions()~~](#withoptions)
+        * [~~withoutBase()~~](#withoutbase)
     * [ResponseInterface](#responseinterface)
     * [RequestInterface](#requestinterface)
     * [UriInterface](#uriinterface)
@@ -1103,41 +1103,42 @@ given setting applied.
 
 #### withBase()
 
-The `withBase(string|UriInterface $baseUri): Browser` method can be used to
+The `withBase(string|null|UriInterface $baseUrl): Browser` method can be used to
 change the base URL used to resolve relative URLs to.
 
+If you configure a base URL, any requests to relative URLs will be
+processed by first prepending this absolute base URL. Note that this
+merely prepends the base URL and does *not* resolve any relative path
+references (like `../` etc.). This is mostly useful for (RESTful) API
+calls where all endpoints (URLs) are located under a common base URL.
+
 ```php
-$newBrowser = $browser->withBase('http://api.example.com/v3');
+$browser = $browser->withBase('http://api.example.com/v3');
+
+// will request http://api.example.com/v3/example
+$browser->get('/example')->then(…);
 ```
+
+You can pass in a `null` base URL to return a new instance that does not
+use a base URL:
+
+```php
+$browser = $browser->withBase(null);
+```
+
+Accordingly, any requests using relative URLs to a browser that does not
+use a base URL can not be completed and will be rejected without sending
+a request.
+
+This method will throw an `InvalidArgumentException` if the given
+`$baseUrl` argument is not a valid URL.
 
 Notice that the [`Browser`](#browser) is an immutable object, i.e. the `withBase()` method
 actually returns a *new* [`Browser`](#browser) instance with the given base URL applied.
 
-Any requests to relative URLs will then be processed by first prepending
-the (absolute) base URL.
-Please note that this merely prepends the base URL and does *not* resolve
-any relative path references (like `../` etc.).
-This is mostly useful for (RESTful) API calls where all endpoints (URLs)
-are located under a common base URL scheme.
-
-```php
-// will request http://api.example.com/v3/example
-$newBrowser->get('/example')->then(…);
-```
-
-#### withoutBase()
-
-The `withoutBase(): Browser` method can be used to
-remove the base URL.
-
-```php
-$newBrowser = $browser->withoutBase();
-```
-
-Notice that the [`Browser`](#browser) is an immutable object, i.e. the `withoutBase()` method
-actually returns a *new* [`Browser`](#browser) instance without any base URL applied.
-
-See also [`withBase()`](#withbase).
+> Changelog: As of v2.9.0 this method accepts a `null` value to reset the
+  base URL. Earlier versions had to use the deprecated `withoutBase()`
+  method to reset the base URL.
 
 #### withProtocolVersion()
 
@@ -1193,6 +1194,23 @@ See also [timeouts](#timeouts), [redirects](#redirects) and
 Notice that the [`Browser`](#browser) is an immutable object, i.e. this
 method actually returns a *new* [`Browser`](#browser) instance with the
 options applied.
+
+#### ~~withoutBase()~~
+
+> Deprecated since v2.9.0, see [`withBase()`](#withbase) instead.
+
+The deprecated `withoutBase(): Browser` method can be used to
+remove the base URL.
+
+```php
+// deprecated: see withBase() instead
+$newBrowser = $browser->withoutBase();
+```
+
+Notice that the [`Browser`](#browser) is an immutable object, i.e. the `withoutBase()` method
+actually returns a *new* [`Browser`](#browser) instance without any base URL applied.
+
+See also [`withBase()`](#withbase).
 
 ### ResponseInterface
 

--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -111,20 +111,15 @@ class MessageFactory
      *
      * If the given $uri is a relative URI, it will simply be appended behind $base URI.
      *
-     * If the given $uri is an absolute URI, it will simply be verified to
-     * be *below* the given $base URI.
+     * If the given $uri is an absolute URI, it will simply be returned as-is.
      *
      * @param UriInterface $uri
      * @param UriInterface $base
      * @return UriInterface
-     * @throws \UnexpectedValueException
      */
     public function expandBase(UriInterface $uri, UriInterface $base)
     {
         if ($uri->getScheme() !== '') {
-            if (strpos((string)$uri, (string)$base) !== 0) {
-                throw new \UnexpectedValueException('Invalid base, "' . $uri . '" does not appear to be below "' . $base . '"');
-            }
             return $uri;
         }
 

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -146,6 +146,30 @@ class FunctionalBrowserTest extends TestCase
         Block\await($this->browser->get($this->base . 'get'), $this->loop);
     }
 
+    public function testGetRequestWithRelativeAddressRejects()
+    {
+        $promise = $this->browser->get('delay');
+
+        $this->setExpectedException('InvalidArgumentException', 'Invalid request URL given');
+        Block\await($promise, $this->loop);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testGetRequestWithBaseAndRelativeAddressResolves()
+    {
+        Block\await($this->browser->withBase($this->base)->get('get'), $this->loop);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testGetRequestWithBaseAndFullAddressResolves()
+    {
+        Block\await($this->browser->withBase('http://example.com/')->get($this->base . 'get'), $this->loop);
+    }
+
     public function testCancelGetRequestWillRejectRequest()
     {
         $promise = $this->browser->get($this->base . 'get');


### PR DESCRIPTION
This changeset improves the `withBase()` method to be more consistent with other methods changing options and deprecates the `withoutBase()` method.

```php
// old: deprecated
$browser = $browser->withoutBase();

// new
$browser = $browser->withBase(null);
```

Previously, each request method could potentially throw an `Exception` when the given absolute URL did not match any base URL configured. This will now simply ignore the base URL and use the given absolute URL as-is. This is not considered a BC break because this is undocumented behavior that is inconsistent with how the rest of this API works.

Builds on top of #172 
Refs #154