### PR TITLE
Add `withResponseBuffer()` method to limit maximum response buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ mess with most of the low-level details.
         * [withRejectErrorResponse()](#withrejecterrorresponse)
         * [withBase()](#withbase)
         * [withProtocolVersion()](#withprotocolversion)
+        * [withResponseBuffer()](#withresponsebuffer)
         * [~~withOptions()~~](#withoptions)
         * [~~withoutBase()~~](#withoutbase)
     * [ResponseInterface](#responseinterface)
@@ -1195,6 +1196,43 @@ $newBrowser->get($url)->then(…);
 Notice that the [`Browser`](#browser) is an immutable object, i.e. this
 method actually returns a *new* [`Browser`](#browser) instance with the
 new protocol version applied.
+
+#### withResponseBuffer()
+
+The `withRespomseBuffer(int $maximumSize): Browser` method can be used to
+change the maximum size for buffering a response body.
+
+The preferred way to send an HTTP request is by using the above
+[request methods](#request-methods), for example the [`get()`](#get)
+method to send an HTTP `GET` request. Each of these methods will buffer
+the whole response body in memory by default. This is easy to get started
+and works reasonably well for smaller responses.
+
+By default, the response body buffer will be limited to 16 MiB. If the
+response body exceeds this maximum size, the request will be rejected.
+
+You can pass in the maximum number of bytes to buffer:
+
+```php
+$browser = $browser->withResponseBuffer(1024 * 1024);
+
+$browser->get($url)->then(function (Psr\Http\Message\ResponseInterface $response) {
+    // response body will not exceed 1 MiB
+    var_dump($response->getHeaders(), (string) $response->getBody());
+});
+```
+
+Note that the response body buffer has to be kept in memory for each
+pending request until its transfer is completed and it will only be freed
+after a pending request is fulfilled. As such, increasing this maximum
+buffer size to allow larger response bodies is usually not recommended.
+Instead, you can use the [`requestStreaming()` method](#requeststreaming)
+to receive responses with arbitrary sizes without buffering. Accordingly,
+this maximum buffer size setting has no effect on streaming responses.
+
+Notice that the [`Browser`](#browser) is an immutable object, i.e. this
+method actually returns a *new* [`Browser`](#browser) instance with the
+given setting applied.
 
 #### ~~withOptions()~~
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "react/event-loop": "^1.0 || ^0.5",
         "react/http-client": "^0.5.10",
         "react/promise": "^2.2.1 || ^1.2.1",
-        "react/promise-stream": "^1.0 || ^0.1.1",
+        "react/promise-stream": "^1.0 || ^0.1.2",
         "react/socket": "^1.1",
         "react/stream": "^1.0 || ^0.7",
         "ringcentral/psr7": "^1.2"

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -745,6 +745,52 @@ class Browser
     }
 
     /**
+     * Changes the maximum size for buffering a response body.
+     *
+     * The preferred way to send an HTTP request is by using the above
+     * [request methods](#request-methods), for example the [`get()`](#get)
+     * method to send an HTTP `GET` request. Each of these methods will buffer
+     * the whole response body in memory by default. This is easy to get started
+     * and works reasonably well for smaller responses.
+     *
+     * By default, the response body buffer will be limited to 16 MiB. If the
+     * response body exceeds this maximum size, the request will be rejected.
+     *
+     * You can pass in the maximum number of bytes to buffer:
+     *
+     * ```php
+     * $browser = $browser->withResponseBuffer(1024 * 1024);
+     *
+     * $browser->get($url)->then(function (Psr\Http\Message\ResponseInterface $response) {
+     *     // response body will not exceed 1 MiB
+     *     var_dump($response->getHeaders(), (string) $response->getBody());
+     * });
+     * ```
+     *
+     * Note that the response body buffer has to be kept in memory for each
+     * pending request until its transfer is completed and it will only be freed
+     * after a pending request is fulfilled. As such, increasing this maximum
+     * buffer size to allow larger response bodies is usually not recommended.
+     * Instead, you can use the [`requestStreaming()` method](#requeststreaming)
+     * to receive responses with arbitrary sizes without buffering. Accordingly,
+     * this maximum buffer size setting has no effect on streaming responses.
+     *
+     * Notice that the [`Browser`](#browser) is an immutable object, i.e. this
+     * method actually returns a *new* [`Browser`](#browser) instance with the
+     * given setting applied.
+     *
+     * @param int $maximumSize
+     * @return self
+     * @see self::requestStreaming()
+     */
+    public function withResponseBuffer($maximumSize)
+    {
+        return $this->withOptions(array(
+            'maximumSize' => $maximumSize
+        ));
+    }
+
+    /**
      * [Deprecated] Changes the [options](#options) to use:
      *
      * The [`Browser`](#browser) class exposes several options for the handling of

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -203,6 +203,13 @@ class BrowserTest extends TestCase
         $this->browser->withRejectErrorResponse(false);
     }
 
+    public function testWithResponseBufferThousandSetsSenderOption()
+    {
+        $this->sender->expects($this->once())->method('withOptions')->with(array('maximumSize' => 1000))->willReturnSelf();
+
+        $this->browser->withResponseBuffer(1000);
+    }
+
     public function testWithBase()
     {
         $browser = $this->browser->withBase('http://example.com/root');


### PR DESCRIPTION
This changeset adds a new `withResponseBuffer()` method to limit the maximum response buffer size for all request methods. The default limit is now 16 MiB and can be changed with this new method.

```php
// new: download maximum of 100 MB
$browser->withResponseBuffer(100 * 1000000)->get($url);
```

This is useful to prevent possible DOS attacks where the client could otherwise run out of memory when receiving a very large response body. Accordingly, this it not considered a BC break even though this might potentially affect existing consumers of this package. The 16 MiB default was chosen as a compromise to not affect most common use cases and still provide a reasonable protection against large responses.

If you're currently processing large responses, you may use the new `withResponseBuffer()` method to increase this limit. As an alternative, you're recommended to use streaming responses which are not affected by this limit and allow processing arbitrary responses.

Builds on top of #172 and #170
Resolves #89 